### PR TITLE
Redid all include directives with include-what-you-use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ x64/
 Debug/
 enc_temp_folder/
 *.aps
+compile_commands.json

--- a/DialogueDemo.sln
+++ b/DialogueDemo.sln
@@ -7,24 +7,18 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DialogueDemo", "DialogueDem
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|ARM = Debug|ARM
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Release|ARM = Release|ARM
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{DFC99971-5B68-4B25-AF9A-A8559F474345}.Debug|ARM.ActiveCfg = Release|ARM
-		{DFC99971-5B68-4B25-AF9A-A8559F474345}.Debug|ARM.Build.0 = Release|ARM
-		{DFC99971-5B68-4B25-AF9A-A8559F474345}.Debug|x64.ActiveCfg = Debug|x64
-		{DFC99971-5B68-4B25-AF9A-A8559F474345}.Debug|x64.Build.0 = Debug|x64
+		{DFC99971-5B68-4B25-AF9A-A8559F474345}.Debug|x64.ActiveCfg = Release|x64
+		{DFC99971-5B68-4B25-AF9A-A8559F474345}.Debug|x64.Build.0 = Release|x64
 		{DFC99971-5B68-4B25-AF9A-A8559F474345}.Debug|x86.ActiveCfg = Debug|Win32
 		{DFC99971-5B68-4B25-AF9A-A8559F474345}.Debug|x86.Build.0 = Debug|Win32
-		{DFC99971-5B68-4B25-AF9A-A8559F474345}.Release|ARM.ActiveCfg = Debug|ARM
-		{DFC99971-5B68-4B25-AF9A-A8559F474345}.Release|ARM.Build.0 = Debug|ARM
-		{DFC99971-5B68-4B25-AF9A-A8559F474345}.Release|x64.ActiveCfg = Release|x64
-		{DFC99971-5B68-4B25-AF9A-A8559F474345}.Release|x64.Build.0 = Release|x64
+		{DFC99971-5B68-4B25-AF9A-A8559F474345}.Release|x64.ActiveCfg = Debug|Win32
+		{DFC99971-5B68-4B25-AF9A-A8559F474345}.Release|x64.Build.0 = Debug|Win32
 		{DFC99971-5B68-4B25-AF9A-A8559F474345}.Release|x86.ActiveCfg = Release|Win32
 		{DFC99971-5B68-4B25-AF9A-A8559F474345}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection

--- a/DialogueDemo.vcxproj
+++ b/DialogueDemo.vcxproj
@@ -1,17 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|ARM">
-      <Configuration>Debug</Configuration>
-      <Platform>ARM</Platform>
-    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|ARM">
-      <Configuration>Release</Configuration>
-      <Platform>ARM</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
@@ -64,18 +56,6 @@
     <CharacterSet>Unicode</CharacterSet>
     <EnableASAN>true</EnableASAN>
   </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
-    <PlatformToolset>v143</PlatformToolset>
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <CharacterSet>Unicode</CharacterSet>
-    <EnableASAN>false</EnableASAN>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
-    <PlatformToolset>v143</PlatformToolset>
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <CharacterSet>Unicode</CharacterSet>
-    <EnableASAN>true</EnableASAN>
-  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -110,18 +90,11 @@
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;LINTER_EXPORTS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;WIN32;_DEBUG;DOCKINGDIALOGUE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -145,6 +118,12 @@
     <ResourceCompile>
       <Culture>0x0809</Culture>
     </ResourceCompile>
+    <PreLinkEvent>
+      <Command>iwyu.bat</Command>
+    </PreLinkEvent>
+    <PreLinkEvent>
+      <Message>Include What You Use checks</Message>
+    </PreLinkEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -152,7 +131,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;DOCKINGDIALOGUE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;WIN32;NDEBUG;DOCKINGDIALOGUE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -163,6 +142,7 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
+      <EnablePREfast>true</EnablePREfast>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -171,12 +151,18 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
     </Link>
+    <PreLinkEvent>
+      <Command>iwyu.bat</Command>
+    </PreLinkEvent>
+    <PreLinkEvent>
+      <Message>Include What You Use checks</Message>
+    </PreLinkEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;LINTER_EXPORTS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;_DEBUG;DOCKINGDIALOGUE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -208,6 +194,12 @@
     <ResourceCompile>
       <Culture>0x0809</Culture>
     </ResourceCompile>
+    <PreLinkEvent>
+      <Command>iwyu.bat</Command>
+    </PreLinkEvent>
+    <PreLinkEvent>
+      <Message>Include What You Use checks</Message>
+    </PreLinkEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -215,7 +207,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;DOCKINGDIALOGUE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;NDEBUG;DOCKINGDIALOGUE_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -226,6 +218,7 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
+      <EnablePREfast>true</EnablePREfast>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -240,60 +233,19 @@
     <PostBuildEvent>
       <Message>Copy DLL to notepad++ plugins folder</Message>
     </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
-    <ClCompile>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>.;./plugintemplate/src</AdditionalIncludeDirectories>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <WarningLevel>Level3</WarningLevel>
-      <TreatWarningAsError>true</TreatWarningAsError>
-      <SDLCheck>true</SDLCheck>
-      <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;LINTER_EXPORTS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
-      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
-      <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalOptions> /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
-      <Optimization>Disabled</Optimization>
-      <DisableLanguageExtensions>true</DisableLanguageExtensions>
-      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
-      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
-    </ClCompile>
-    <Link>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-    <Link>
-      <AssemblyDebug>true</AssemblyDebug>
-      <SubSystem>Windows</SubSystem>
-    </Link>
-    <ResourceCompile>
-      <Culture>0x0809</Culture>
-      <PreprocessorDefinitions>_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ResourceCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
-    <ClCompile>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>.;./plugintemplate/src</AdditionalIncludeDirectories>
-      <WarningLevel>Level3</WarningLevel>
-      <TreatWarningAsError>true</TreatWarningAsError>
-      <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <DisableLanguageExtensions>true</DisableLanguageExtensions>
-      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
-      <ConformanceMode>true</ConformanceMode>
-      <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
-      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
-    </ClCompile>
+    <PreLinkEvent>
+      <Command>iwyu.bat</Command>
+    </PreLinkEvent>
+    <PreLinkEvent>
+      <Message>Include What You Use checks</Message>
+    </PreLinkEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="demo\About_Dialogue.h" />
     <ClInclude Include="demo\Demo_Plugin.h" />
     <ClInclude Include="demo\Goto_Dialogue.h" />
     <ClInclude Include="demo\resource.h" />
+    <ClInclude Include="Min_Win_Defs.h" />
     <ClInclude Include="plugintemplate\src\DockingFeature\Docking.h" />
     <ClInclude Include="plugintemplate\src\DockingFeature\dockingResource.h" />
     <ClInclude Include="plugintemplate\src\menuCmdID.h" />
@@ -320,14 +272,14 @@
     <ClCompile Include="Plugin\Non_Modal_Dialogue_Base.cpp" />
     <ClCompile Include="Plugin\Non_Modal_Dialogue_Interface.cpp" />
     <ClCompile Include="Plugin\Plugin.cpp" />
+    <None Include="iwyu.bat" />
     <None Include="Template\dllmain.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </None>
+    <None Include="vc2022cpp17.imp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="cpp.hint" />

--- a/DialogueDemo.vcxproj.filters
+++ b/DialogueDemo.vcxproj.filters
@@ -80,6 +80,9 @@
     <ClInclude Include="plugintemplate\src\DockingFeature\dockingResource.h">
       <Filter>Notepad++ Headers\DockingFeature</Filter>
     </ClInclude>
+    <ClInclude Include="Min_Win_Defs.h">
+      <Filter>Source Files\Source</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="demo\Demo_Plugin.cpp">
@@ -120,6 +123,8 @@
     <None Include="Template\dllmain.cpp">
       <Filter>Source Files\Template</Filter>
     </None>
+    <None Include="iwyu.bat" />
+    <None Include="vc2022cpp17.imp" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="demo\icon1.ico">

--- a/DialogueDemo.vcxproj.user
+++ b/DialogueDemo.vcxproj.user
@@ -6,6 +6,12 @@
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <LocalDebuggerEnvironment />
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LocalDebuggerCommand>C:\Program Files\Notepad++\notepad++.exe</LocalDebuggerCommand>
+    <LocalDebuggerWorkingDirectory>C:\Program Files\Notepad++</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+    <LocalDebuggerEnvironment />
+  </PropertyGroup>
   <PropertyGroup>
     <ShowAllFiles>false</ShowAllFiles>
   </PropertyGroup>

--- a/Min_Win_Defs.h
+++ b/Min_Win_Defs.h
@@ -1,0 +1,15 @@
+#pragma once
+// Forward declarations from windows windef.h / minwindef.h (mostly) which
+// fail to build if you add them as per suggestions...
+
+#include <basetsd.h>
+
+typedef struct tagRECT RECT;
+typedef struct HWND__ *HWND;
+typedef unsigned int UINT;
+typedef UINT_PTR WPARAM;
+typedef LONG_PTR LPARAM;
+typedef LONG_PTR LRESULT;
+typedef void *HANDLE;
+typedef struct HICON__ *HICON;
+typedef int BOOL;

--- a/Plugin/Callback_Context.h
+++ b/Plugin/Callback_Context.h
@@ -15,8 +15,8 @@
 
 /** This contains a class which permits easy (ish) setup of callbacks.
  *
- * To use it you have to create a static map of an array of callbacks like this (and
- * sadly it must be a static)
+ * To use it you have to create a static map of an array of callbacks like this
+ * (and sadly it must be a static)
  *
  *
  * typedef Callback_Context_Base<My_Plugin> Callbacks;
@@ -36,9 +36,11 @@
  *
  * Callbacks::contexts[entry]->free(this, callback);
  */
-
 #include <memory>
 #include <unordered_map>
+
+//Stolen from PluginInterface.h
+typedef void(__cdecl *PFUNCPLUGINCMD)();
 
 template <class Callback_Class>
 class Callback_Context_Base
@@ -48,9 +50,9 @@ class Callback_Context_Base
 
   public:
     Callback_Context_Base(PFUNCPLUGINCMD callback) noexcept :
+        callback_(callback),
         instance_(nullptr),
-        method_(nullptr),
-        callback_(callback)
+        method_(nullptr)
     {
     }
 
@@ -89,7 +91,7 @@ class Callback_Context_Base
     /** This is for setting up menu separators.
      *
      * It is a bit of a crock. It always returns nullptr, so you can't actually
-     * tell if it worked or not. It does however reserve a slot if succesful.
+     * tell if it worked or not. It does however reserve a slot if successful.
      */
     PFUNCPLUGINCMD reserve(Callback_Class *instance, nullptr_t method) noexcept
     {

--- a/Plugin/Dialogue_Interface.h
+++ b/Plugin/Dialogue_Interface.h
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include "Min_Win_Defs.h"
+
 #include <basetsd.h>
 
 #include <functional>
@@ -21,15 +23,7 @@
 #include <string>
 #include <unordered_map>
 
-// Forward declarations from windows headers. Sorry.
-typedef struct tagRECT RECT;
-typedef struct HWND__ *HWND;
-typedef unsigned int UINT;
-typedef UINT_PTR WPARAM;
-typedef LONG_PTR LPARAM;
-typedef LONG_PTR LRESULT;
-typedef void *HANDLE;
-
+// Forward references
 class Plugin;
 
 class Dialogue_Interface
@@ -114,6 +108,9 @@ class Dialogue_Interface
     /** Allows you to subclass a window element, to intercept events on it */
     void add_item_callback(int item, Item_Callback_Function callback_func);
 
+    /** Return type for dialogue message callbacks */
+    typedef std::optional<INT_PTR> Message_Return;
+
   private:
     /** Implement this to handle messages.
      *
@@ -128,12 +125,12 @@ class Dialogue_Interface
      * message, wParam and lParam are the values passed to
      * process_dialogue_message by windows
      */
-    virtual std::optional<INT_PTR> on_dialogue_message(
+    virtual Message_Return on_dialogue_message(
         UINT message, WPARAM wParam, LPARAM lParam
     ) noexcept(false);
 
     /** Handler for unhandled messages */
-    virtual std::optional<INT_PTR> on_unhandled_dialogue_message(
+    virtual Message_Return on_unhandled_dialogue_message(
         UINT message, WPARAM wParam, LPARAM lParam
     ) noexcept;
 

--- a/Plugin/Docking_Dialogue_Interface.cpp
+++ b/Plugin/Docking_Dialogue_Interface.cpp
@@ -20,7 +20,9 @@
 #include "DockingFeature/dockingResource.h"
 #include "Notepad_plus_msgs.h"
 
-#include <WinUser.h>
+#include <windows.h>
+
+#include <optional>
 
 Docking_Dialogue_Interface::Docking_Dialogue_Interface(
     int dialogue_ID, Plugin const *plugin
@@ -96,7 +98,8 @@ void Docking_Dialogue_Interface::on_hide() noexcept
 {
 }
 
-std::optional<LONG_PTR> Docking_Dialogue_Interface::on_unhandled_non_modal_dialogue_message(
+Docking_Dialogue_Interface::Message_Return
+Docking_Dialogue_Interface::on_unhandled_non_modal_dialogue_message(
     UINT message, WPARAM, LPARAM lParam
 ) noexcept
 {

--- a/Plugin/Docking_Dialogue_Interface.h
+++ b/Plugin/Docking_Dialogue_Interface.h
@@ -13,16 +13,11 @@
 
 #pragma once
 
-#include "Non_Modal_Dialogue_Interface.h"
+#include "Non_Modal_Dialogue_Base.h"
 
-#include <basetsd.h>
+#include "Min_Win_Defs.h"
 
-#include <optional>
-
-// Forward declarations from windows headers
-typedef struct HICON__ *HICON;
-
-// Forward declarations.
+// Forward refs
 class Plugin;
 
 /** This provides an abstraction for creating a docking dialogue. */
@@ -92,7 +87,7 @@ class Docking_Dialogue_Interface : public Non_Modal_Dialogue_Base
     virtual void on_hide() noexcept;
 
     /** Handler for unhandled messages */
-    std::optional<LONG_PTR> on_unhandled_non_modal_dialogue_message(
+    Message_Return on_unhandled_non_modal_dialogue_message(
         UINT message, WPARAM wParam, LPARAM lParam
     ) noexcept override final;
 

--- a/Plugin/Modal_Dialogue_Interface.cpp
+++ b/Plugin/Modal_Dialogue_Interface.cpp
@@ -14,9 +14,9 @@
 
 #include "Modal_Dialogue_Interface.h"
 
-#include "Plugin/Plugin.h"
+#include <windows.h>
 
-#include <WinUser.h>
+#include <optional>
 
 Modal_Dialogue_Interface::Modal_Dialogue_Interface(Plugin const *plugin) :
     Dialogue_Interface(plugin),
@@ -40,17 +40,20 @@ BOOL Modal_Dialogue_Interface::centre_dialogue() const noexcept
     int const height = rect.bottom - rect.top;
 
     RECT const rect_npp = getParentRect();
-    int const x = ((rect_npp.right - rect_npp.left) - width) / 2 + rect_npp.left;
-    int const y = ((rect_npp.bottom - rect_npp.top) - height) / 2 + rect_npp.top;
+    int const x =
+        ((rect_npp.right - rect_npp.left) - width) / 2 + rect_npp.left;
+    int const y =
+        ((rect_npp.bottom - rect_npp.top) - height) / 2 + rect_npp.top;
 
     return ::MoveWindow(window(), x, y, width, height, TRUE);
 }
 
-std::optional<LONG_PTR> Modal_Dialogue_Interface::on_unhandled_dialogue_message(
+Modal_Dialogue_Interface::Message_Return
+Modal_Dialogue_Interface::on_unhandled_dialogue_message(
     UINT message, WPARAM wParam, LPARAM lParam
 ) noexcept
 {
-    //This provides default handlers for OK, cancel, and close clicks.
+    // This provides default handlers for OK, cancel, and close clicks.
     switch (message)
     {
         case WM_COMMAND:

--- a/Plugin/Modal_Dialogue_Interface.h
+++ b/Plugin/Modal_Dialogue_Interface.h
@@ -15,12 +15,9 @@
 
 #include "Dialogue_Interface.h"
 
+#include "Min_Win_Defs.h"
+
 #include <basetsd.h>
-
-#include <optional>
-
-// Forward declarations from windows headers
-typedef int BOOL;
 
 // Forward declarations.
 class Plugin;
@@ -79,7 +76,7 @@ class Modal_Dialogue_Interface : public Dialogue_Interface
 
   private:
     /** Handler for unhandled messages */
-    std::optional<LONG_PTR> on_unhandled_dialogue_message(
+    Message_Return on_unhandled_dialogue_message(
         UINT message, WPARAM wParam, LPARAM lParam
     ) noexcept override final;
 

--- a/Plugin/Non_Modal_Dialogue_Base.cpp
+++ b/Plugin/Non_Modal_Dialogue_Base.cpp
@@ -15,7 +15,11 @@
 
 #include "Plugin.h"
 
-#include <Notepad_plus_msgs.h>
+#include "Notepad_plus_msgs.h"
+
+#include <windows.h>
+
+#include <optional>
 
 Non_Modal_Dialogue_Base::Non_Modal_Dialogue_Base(
     int dialogue_ID, Plugin const *plugin, HWND parent
@@ -36,7 +40,7 @@ void Non_Modal_Dialogue_Base::send_dialogue_info(int msg, int wParam) noexcept
     plugin()->send_to_notepad(msg, wParam, window());
 }
 
-std::optional<LONG_PTR>
+Non_Modal_Dialogue_Base::Message_Return
 Non_Modal_Dialogue_Base::on_unhandled_non_modal_dialogue_message(
     UINT message, WPARAM wParam, LPARAM lParam
 ) noexcept
@@ -44,7 +48,8 @@ Non_Modal_Dialogue_Base::on_unhandled_non_modal_dialogue_message(
     return std::nullopt;
 }
 
-std::optional<LONG_PTR> Non_Modal_Dialogue_Base::on_unhandled_dialogue_message(
+Non_Modal_Dialogue_Base::Message_Return
+Non_Modal_Dialogue_Base::on_unhandled_dialogue_message(
     UINT message, WPARAM wParam, LPARAM lParam
 ) noexcept
 {

--- a/Plugin/Non_Modal_Dialogue_Base.h
+++ b/Plugin/Non_Modal_Dialogue_Base.h
@@ -15,9 +15,7 @@
 
 #include "Dialogue_Interface.h"
 
-#include <basetsd.h>
-
-#include <optional>
+#include "Min_Win_Defs.h"
 
 // Forward declarations.
 class Plugin;
@@ -30,7 +28,9 @@ class Non_Modal_Dialogue_Base : public Dialogue_Interface
      *
      * dialogue_id is the resource number of the dialogue
      */
-    Non_Modal_Dialogue_Base(int dialogue_id, Plugin const *plugin, HWND parent = nullptr);
+    Non_Modal_Dialogue_Base(
+        int dialogue_id, Plugin const *plugin, HWND parent = nullptr
+    );
 
     Non_Modal_Dialogue_Base(Non_Modal_Dialogue_Base const &) = delete;
     Non_Modal_Dialogue_Base(Non_Modal_Dialogue_Base &&) = delete;
@@ -46,12 +46,12 @@ class Non_Modal_Dialogue_Base : public Dialogue_Interface
 
   private:
     /** Implement this to handle other unhandled messages */
-    virtual std::optional<LONG_PTR> on_unhandled_non_modal_dialogue_message(
+    virtual Message_Return on_unhandled_non_modal_dialogue_message(
         UINT message, WPARAM wParam, LPARAM lParam
     ) noexcept;
 
     /** Handler for unhandled messages */
-    std::optional<LONG_PTR> on_unhandled_dialogue_message(
+    Message_Return on_unhandled_dialogue_message(
         UINT message, WPARAM wParam, LPARAM lParam
     ) noexcept override final;
 

--- a/Plugin/Non_Modal_Dialogue_Interface.cpp
+++ b/Plugin/Non_Modal_Dialogue_Interface.cpp
@@ -13,7 +13,9 @@
 
 #include "Non_Modal_Dialogue_Interface.h"
 
-#include "Plugin.h"
+#include <optional>
+
+class Plugin;
 
 Non_Modal_Dialogue_Interface::Non_Modal_Dialogue_Interface(
     int dialogue_ID, Plugin const *plugin, HWND parent
@@ -26,7 +28,7 @@ Non_Modal_Dialogue_Interface::~Non_Modal_Dialogue_Interface()
 {
 }
 
-std::optional<LONG_PTR>
+Non_Modal_Dialogue_Interface::Message_Return
 Non_Modal_Dialogue_Interface::on_unhandled_non_modal_dialogue_message(
     UINT message, WPARAM wParam, LPARAM lParam
 ) noexcept

--- a/Plugin/Non_Modal_Dialogue_Interface.h
+++ b/Plugin/Non_Modal_Dialogue_Interface.h
@@ -15,15 +15,13 @@
 
 #include "Non_Modal_Dialogue_Base.h"
 
-#include <basetsd.h>
+#include "Min_Win_Defs.h"
 
-#include <optional>
-
-// Forward declarations.
+// Forward references
 class Plugin;
 
 /** This provides an abstraction for creating a non modal non docking dialogue.
- * 
+ *
  */
 class Non_Modal_Dialogue_Interface : public Non_Modal_Dialogue_Base
 {
@@ -32,7 +30,9 @@ class Non_Modal_Dialogue_Interface : public Non_Modal_Dialogue_Base
      *
      * dialogue_id is the resource number of the dialogue
      */
-    Non_Modal_Dialogue_Interface(int dialogue_id, Plugin const *plugin, HWND parent = nullptr);
+    Non_Modal_Dialogue_Interface(
+        int dialogue_id, Plugin const *plugin, HWND parent = nullptr
+    );
 
     Non_Modal_Dialogue_Interface(Non_Modal_Dialogue_Interface const &) = delete;
     Non_Modal_Dialogue_Interface(Non_Modal_Dialogue_Interface &&) = delete;
@@ -48,7 +48,7 @@ class Non_Modal_Dialogue_Interface : public Non_Modal_Dialogue_Base
      *
      * Needs to exist so it can be final.
      */
-    std::optional<LONG_PTR> on_unhandled_non_modal_dialogue_message(
+    Message_Return on_unhandled_non_modal_dialogue_message(
         UINT message, WPARAM wParam, LPARAM lParam
     ) noexcept override final;
 };

--- a/Plugin/Plugin.cpp
+++ b/Plugin/Plugin.cpp
@@ -16,10 +16,11 @@
 #include "Notepad_plus_msgs.h"
 #include "Scintilla.h"
 
-#include <WinUser.h>
 #include <libloaderapi.h>
+#include <windows.h>
 
 #include <memory>
+#include <string>
 #include <vector>
 
 static Plugin *plugin;
@@ -111,7 +112,7 @@ std::string Plugin::get_line_text(int line) const
     return std::string(buff.get(), length);
 }
 
-int Plugin::message_box(std::wstring const & message, UINT type) const noexcept
+int Plugin::message_box(std::wstring const &message, UINT type) const noexcept
 {
     return ::MessageBox(
         get_notepad_window(), message.c_str(), name_.c_str(), type
@@ -134,7 +135,9 @@ extern "C"
 {
     FuncItem *Plugin::getFuncsArray(int *nbF)
     {
+#ifdef __FUNCDNAME__
 #pragma comment(linker, "/EXPORT:getFuncsArray=" __FUNCDNAME__)
+#endif
         auto &res = plugin->on_get_menu_entries();
         *nbF = static_cast<int>(res.size());
         return &*res.begin();
@@ -142,13 +145,17 @@ extern "C"
 
     void Plugin::beNotified(SCNotification *notification)
     {
+#ifdef __FUNCDNAME__
 #pragma comment(linker, "/EXPORT:beNotified=" __FUNCDNAME__)
+#endif
         plugin->on_notification(notification);
     }
 
     LRESULT Plugin::messageProc(UINT message, WPARAM wParam, LPARAM lParam)
     {
+#ifdef __FUNCDNAME__
 #pragma comment(linker, "/EXPORT:messageProc=" __FUNCDNAME__)
+#endif
         return plugin->on_message(message, wParam, lParam);
     }
 }

--- a/Plugin/Plugin.h
+++ b/Plugin/Plugin.h
@@ -15,13 +15,15 @@
 
 #include "PluginInterface.h"
 
+#include <windows.h>
+
+#include <cwchar>
 #include <memory>
 #include <string>
 #include <string_view>
-#include <tuple>
 #include <vector>
 
-class SCNotification;
+struct SCNotification;
 
 class Plugin
 {
@@ -99,13 +101,9 @@ class Plugin
     )
     {
         contexts[entry] = std::make_unique<Context>(context);
-        //In C++20 this could be made a little easier to read.
+        // In C++20 this could be made a little easier to read.
         FuncItem item;
-        std::ignore = lstrcpyn(
-            &item._itemName[0],
-            message,
-            sizeof(item._itemName) / sizeof(wchar_t)
-        );
+        wcsncpy_s(item._itemName, message, wcslen(message));
         item._pFunc = contexts[entry]->reserve(self, callback);
         item._cmdID = entry;
         item._init2Check = checked;
@@ -174,7 +172,7 @@ class Plugin
         Callbacks::contexts,                                       \
         Callback_Context<class, entry>(),                          \
         this,                                                      \
-        &class::method,                                            \
+        &class ::method,                                           \
         __VA_ARGS__                                                \
     )
 

--- a/Plugin/Plugin.h
+++ b/Plugin/Plugin.h
@@ -15,6 +15,7 @@
 
 #include "PluginInterface.h"
 
+#include <corecrt.h> // for _TRUNCATE
 #include <windows.h>
 
 #include <cwchar>
@@ -103,7 +104,7 @@ class Plugin
         contexts[entry] = std::make_unique<Context>(context);
         // In C++20 this could be made a little easier to read.
         FuncItem item;
-        wcsncpy_s(item._itemName, message, wcslen(message));
+        wcsncpy_s(item._itemName, message, _TRUNCATE);
         item._pFunc = contexts[entry]->reserve(self, callback);
         item._cmdID = entry;
         item._init2Check = checked;

--- a/Template/dllmain.cpp
+++ b/Template/dllmain.cpp
@@ -12,11 +12,13 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
-#include "PluginInterface.h"
-
 // Modify these 2 lines as appropriate for your plugin.
 #include "My_Plugin.h"
 typedef My_Plugin Npp_Plugin;
+
+#include "PluginInterface.h"
+
+#include <minwindef.h>
 
 #include <memory>
 

--- a/demo/About_Dialogue.cpp
+++ b/demo/About_Dialogue.cpp
@@ -16,7 +16,8 @@
 #include "resource.h"
 
 #include <windows.h>
-//#include <WinUser.h>
+
+#include <optional>
 
 About_Dialogue::About_Dialogue(Plugin const *plugin) :
     Modal_Dialogue_Interface(plugin)
@@ -26,7 +27,7 @@ About_Dialogue::About_Dialogue(Plugin const *plugin) :
 
 About_Dialogue::~About_Dialogue() = default;
 
-std::optional<LONG_PTR> About_Dialogue::on_dialogue_message(
+About_Dialogue::Message_Return About_Dialogue::on_dialogue_message(
     UINT message, WPARAM wParam, LPARAM lParam
 ) noexcept
 {
@@ -34,7 +35,7 @@ std::optional<LONG_PTR> About_Dialogue::on_dialogue_message(
     {
         case WM_INITDIALOG:
         {
-            //Possibly this should be default behaviour?
+            // Possibly this should be default behaviour?
             centre_dialogue();
         }
         break;

--- a/demo/About_Dialogue.h
+++ b/demo/About_Dialogue.h
@@ -14,6 +14,7 @@
 #pragma once
 #include "Plugin/Modal_Dialogue_Interface.h"
 
+// Forward references
 class Plugin;
 
 class About_Dialogue : public Modal_Dialogue_Interface
@@ -24,7 +25,7 @@ class About_Dialogue : public Modal_Dialogue_Interface
     ~About_Dialogue();
 
   private:
-    std::optional<LONG_PTR> on_dialogue_message(
+    Message_Return on_dialogue_message(
         UINT message, WPARAM wParam, LPARAM lParam
     ) noexcept override;
 };

--- a/demo/Demo_Plugin.cpp
+++ b/demo/Demo_Plugin.cpp
@@ -19,8 +19,12 @@
 
 #include "Plugin/Callback_Context.h"
 
+#include "Notepad_plus_msgs.h"
+#include "PluginInterface.h"
 #include "Scintilla.h"
 #include "menuCmdID.h"
+
+#include <windows.h>
 
 #include <memory>
 #include <vector>
@@ -54,7 +58,11 @@ std::vector<FuncItem> &Demo_Plugin::on_get_menu_entries()
             Menu_Entry_Hello_File, L"Hello Notepad++ File", hello_file
         ),
         MAKE_CALLBACK(
-            Menu_Entry_Hello_Message, L"Hello Notepad++ Message", hello_message, false, &f5
+            Menu_Entry_Hello_Message,
+            L"Hello Notepad++ Message",
+            hello_message,
+            false,
+            &f5
         ),
         MAKE_SEPARATOR(Menu_Entry_Separator_1),
         MAKE_CALLBACK(

--- a/demo/Demo_Plugin.h
+++ b/demo/Demo_Plugin.h
@@ -16,11 +16,12 @@
 
 #include "Plugin/Plugin.h"
 
-#include "PluginInterface.h"
-
 #include <memory>
 
+// Forward declarations
 class Goto_Dialogue;
+struct FuncItem;
+struct NppData;
 
 class Demo_Plugin : public Plugin
 {

--- a/demo/Goto_Dialogue.cpp
+++ b/demo/Goto_Dialogue.cpp
@@ -13,13 +13,15 @@
 
 #include "Goto_Dialogue.h"
 
-#include "Plugin/Plugin.h"
-
 #include "resource.h"
 
-#include <WinUser.h>
-#include <Windows.h>
+#include "Plugin/Plugin.h"
 
+#include "Scintilla.h"
+
+#include <windows.h>
+
+#include <optional>
 #include <sstream>
 
 Goto_Dialogue::Goto_Dialogue(int menu_entry, Plugin const *plugin) :
@@ -42,7 +44,7 @@ Goto_Dialogue::Goto_Dialogue(int menu_entry, Plugin const *plugin) :
 
 Goto_Dialogue::~Goto_Dialogue() = default;
 
-std::optional<LONG_PTR> Goto_Dialogue::on_dialogue_message(
+Goto_Dialogue::Message_Return Goto_Dialogue::on_dialogue_message(
     UINT message, WPARAM wParam, LPARAM lParam
 )
 {

--- a/demo/Goto_Dialogue.h
+++ b/demo/Goto_Dialogue.h
@@ -25,7 +25,7 @@ class Goto_Dialogue : public Docking_Dialogue_Interface
     ~Goto_Dialogue();
 
   private:
-    std::optional<LONG_PTR> on_dialogue_message(
+    Message_Return on_dialogue_message(
         UINT message, WPARAM wParam, LPARAM lParam
     ) override;
 

--- a/demo/dllmain.cpp
+++ b/demo/dllmain.cpp
@@ -12,10 +12,12 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
-#include "PluginInterface.h"
-
 #include "Demo_Plugin.h"
 typedef Demo_Plugin Npp_Plugin;
+
+#include "PluginInterface.h"
+
+#include <windows.h>
 
 #include <memory>
 

--- a/iwyu.bat
+++ b/iwyu.bat
@@ -1,0 +1,5 @@
+SET IWYU_PATH="..\Include What You Use\include-what-you-use"
+SET IWYU=%IWYU_PATH%\iwyu_tool.py
+if exist %IWYU% (
+	python.exe %IWYU% -j 5 -v -p .\compile_commands.json -o clang-warning -- -Xiwyu --mapping_file=%IWYU_PATH%\vs2022.imp
+)


### PR DESCRIPTION
This is basically just a cleanup, but I've used include-what-you-use to drive the #include checking.

If you don't have include what you use, don't worry. the build of the demo does a check for it.