### PR TITLE
Cpp20 compat and IWYU fixes

### DIFF
--- a/Plugin/Dialogue_Interface.cpp
+++ b/Plugin/Dialogue_Interface.cpp
@@ -20,7 +20,9 @@
 #include <comutil.h>
 #include <errhandlingapi.h>
 #include <libloaderapi.h>
-#include <windows.h>
+#include <minwindef.h>
+#include <windef.h>
+#include <winuser.h>
 
 #include <cstdio>
 #include <exception>

--- a/Plugin/Dialogue_Interface.h
+++ b/Plugin/Dialogue_Interface.h
@@ -102,7 +102,8 @@ class Dialogue_Interface
      */
     virtual INT_PTR create_modal_dialogue(int dialogue) noexcept;
 
-    typedef std::function<std::optional<LRESULT>(HWND, UINT, WPARAM, LPARAM)>
+    typedef std::optional<LRESULT> Item_Callback_Return;
+    typedef std::function<Item_Callback_Return(HWND, UINT, WPARAM, LPARAM)>
         Item_Callback_Function;
 
     /** Allows you to subclass a window element, to intercept events on it */

--- a/Plugin/Docking_Dialogue_Interface.cpp
+++ b/Plugin/Docking_Dialogue_Interface.cpp
@@ -20,7 +20,9 @@
 #include "DockingFeature/dockingResource.h"
 #include "Notepad_plus_msgs.h"
 
-#include <windows.h>
+#include <minwindef.h>
+#include <windef.h>
+#include <winuser.h>
 
 #include <optional>
 

--- a/Plugin/Min_Win_Defs.h
+++ b/Plugin/Min_Win_Defs.h
@@ -2,6 +2,7 @@
 // Forward declarations from windows windef.h / minwindef.h (mostly) which
 // fail to build if you add them as per suggestions...
 
+#ifndef _WINDOWS_
 #include <basetsd.h>
 
 typedef struct tagRECT RECT;
@@ -13,3 +14,4 @@ typedef LONG_PTR LRESULT;
 typedef void *HANDLE;
 typedef struct HICON__ *HICON;
 typedef int BOOL;
+#endif

--- a/Plugin/Modal_Dialogue_Interface.cpp
+++ b/Plugin/Modal_Dialogue_Interface.cpp
@@ -14,7 +14,11 @@
 
 #include "Modal_Dialogue_Interface.h"
 
-#include <windows.h>
+#include <windows.h>   // IWYU pragma: keep
+
+#include <minwindef.h>
+#include <windef.h>
+#include <winuser.h>
 
 #include <optional>
 

--- a/Plugin/Non_Modal_Dialogue_Base.cpp
+++ b/Plugin/Non_Modal_Dialogue_Base.cpp
@@ -17,7 +17,8 @@
 
 #include "Notepad_plus_msgs.h"
 
-#include <windows.h>
+#include <minwindef.h>
+#include <windef.h>
 
 #include <optional>
 

--- a/Plugin/Plugin.cpp
+++ b/Plugin/Plugin.cpp
@@ -17,7 +17,9 @@
 #include "Scintilla.h"
 
 #include <libloaderapi.h>
-#include <windows.h>
+#include <windows.h> // IWYU pragma: keep
+
+#include <winuser.h>
 
 #include <memory>
 #include <string>

--- a/Plugin/Plugin.cpp
+++ b/Plugin/Plugin.cpp
@@ -50,7 +50,7 @@ std::wstring Plugin::get_config_dir() const
 {
     auto const len = send_to_notepad(NPPM_GETPLUGINSCONFIGDIR, 0, nullptr);
 #if __cplusplus >= 202002L
-    auto buff{std::make_unique_for_overwrite<wchar_t[]>(lengthDoc + 1)};
+    auto buff{std::make_unique_for_overwrite<wchar_t[]>(len + 1)};
 #else
 #pragma warning(suppress : 26409 26414)
     std::unique_ptr<wchar_t[]> buff{new wchar_t[len + 1]};

--- a/Plugin/Plugin.h
+++ b/Plugin/Plugin.h
@@ -16,7 +16,10 @@
 #include "PluginInterface.h"
 
 #include <corecrt.h> // for _TRUNCATE
-#include <windows.h>
+#include <windows.h> // IWYU pragma: keep
+
+#include <minwindef.h>
+#include <windef.h>
 
 #include <cwchar>
 #include <memory>

--- a/demo/About_Dialogue.cpp
+++ b/demo/About_Dialogue.cpp
@@ -15,7 +15,10 @@
 
 #include "resource.h"
 
-#include <windows.h>
+#include <windows.h>  // IWYU pragma: keep
+
+#include <minwindef.h>
+#include <winuser.h>
 
 #include <optional>
 

--- a/demo/Demo_Plugin.cpp
+++ b/demo/Demo_Plugin.cpp
@@ -24,7 +24,9 @@
 #include "Scintilla.h"
 #include "menuCmdID.h"
 
-#include <windows.h>
+#include <windows.h>    // IWYU pragma: keep
+
+#include <winuser.h>
 
 #include <memory>
 #include <vector>

--- a/demo/Goto_Dialogue.cpp
+++ b/demo/Goto_Dialogue.cpp
@@ -19,7 +19,11 @@
 
 #include "Scintilla.h"
 
-#include <windows.h>
+#include <windows.h> // IWYU pragma: keep
+
+#include <minwindef.h>
+#include <windef.h>
+#include <winuser.h>
 
 #include <optional>
 #include <sstream>

--- a/demo/dllmain.cpp
+++ b/demo/dllmain.cpp
@@ -17,7 +17,9 @@ typedef Demo_Plugin Npp_Plugin;
 
 #include "PluginInterface.h"
 
-#include <windows.h>
+#include <windows.h> // IWYU pragma: keep
+
+#include <minwindef.h>
 
 #include <memory>
 


### PR DESCRIPTION
Note that this still gets spurious IWYU warnings because there's still an outstanding ticket that override definitions should not need to pull in headers.